### PR TITLE
Fix SectionHead not center

### DIFF
--- a/components/SectionHead.vue
+++ b/components/SectionHead.vue
@@ -38,6 +38,7 @@ const Container = styled('div', { align: String, size: String })`
 
   text-align: ${props => props.align};
   letter-spacing: 0.4em;
+  margin-left: 0.4em;
   text-transform: uppercase;
 
   user-select: none;
@@ -45,6 +46,7 @@ const Container = styled('div', { align: String, size: String })`
   @media screen and (max-width:768px) {
     text-align: center;
     letter-spacing: 0.3em;
+    margin-left: 0.3em;
     font-size: ${props => sizes[props.size].fontSmallSize}px;
   }
 `

--- a/components/sections/Sponsor.vue
+++ b/components/sections/Sponsor.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="container">
-    <SectionHead title="Sponsors" style="position: sticky; top: 0;"/>
+    <SectionHead title="Sponsors" class="height" style="position: sticky; top: 0;"/>
     <div class="sponsor-vip-wrapper position-relative">
       <SponsorCircle
         :transparent="true"
@@ -90,6 +90,11 @@ export default {
 <style scoped>
 section {
   margin-top: 100px;
+}
+@media screen and (max-width:768px) {
+  .height {
+    font-size: 36px;
+  }
 }
 </style>
 <style lang="scss" scoped>


### PR DESCRIPTION
- Reduce Sponsors heading size on mobile.
- Try adding left margin to reduce effect of letter spacing on last character.