### PR TITLE
Enable SPA fallback for Firebase (routes and error page support)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,7 +12,7 @@
       "rewrites": [
         {
           "source": "**",
-          "destination": "/index.html"
+          "destination": "/200.html"
         }
       ]
     },
@@ -27,7 +27,7 @@
       "rewrites": [
         {
           "source": "**",
-          "destination": "/index.html"
+          "destination": "/200.html"
         }
       ]
     }

--- a/firebase.json
+++ b/firebase.json
@@ -12,7 +12,7 @@
       "rewrites": [
         {
           "source": "**",
-          "destination": "/200.html"
+          "destination": "/404.html"
         }
       ]
     },
@@ -27,7 +27,7 @@
       "rewrites": [
         {
           "source": "**",
-          "destination": "/200.html"
+          "destination": "/404.html"
         }
       ]
     }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -42,7 +42,7 @@ export default {
       return (this.error && this.error.statusCode) || 500
     },
     message () {
-      if (1 === 0 && process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production') {
         return this.error.message || `Client Error`
       } else {
         switch (this.statusCode) {

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="__nuxt-error-page">
+    <div class="error">
+      <svg xmlns="http://www.w3.org/2000/svg" width="90" height="90" :fill="fillColor" viewBox="0 0 48 48">
+        <path d="M22 30h4v4h-4zm0-16h4v12h-4zm1.99-10C12.94 4 4 12.95 4 24s8.94 20 19.99 20S44 35.05 44 24 35.04 4 23.99 4zM24 40c-8.84 0-16-7.16-16-16S15.16 8 24 8s16 7.16 16 16-7.16 16-16 16z" />
+      </svg>
+
+      <div class="error-title">{{ message }}</div>
+      <p v-if="$route.path !== '/'" class="description">
+        <NuxtLink class="error-link" to="/">กลับสู่หน้าแรก</NuxtLink>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+import color from '~/utils/color'
+export default {
+  name: 'NuxtError',
+  props: {
+    error: {
+      type: Object,
+      default: null
+    }
+  },
+  head () {
+    return {
+      title: this.message,
+      meta: [
+        {
+          name: 'viewport',
+          content: 'width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no'
+        }
+      ]
+    }
+  },
+  computed: {
+    fillColor () {
+      return color.main
+    },
+    statusCode () {
+      return (this.error && this.error.statusCode) || 500
+    },
+    message () {
+      if (1 === 0 && process.env.NODE_ENV !== 'production') {
+        return this.error.message || `Client Error`
+      } else {
+        switch (this.statusCode) {
+          case 404: return 'ไม่พบหน้าที่คุณต้องการ'
+          case 500: return 'เกิดข้อผิดพลาดภายในเซิร์ฟเวอร์'
+          default: return 'เกิดข้อผิดพลาดบางประการ'
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style type="scss">
+.__nuxt-error-page {
+  padding: 1rem;
+  background: black;
+  color: white;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+.__nuxt-error-page .error {
+  max-width: 450px;
+}
+.__nuxt-error-page .error-title {
+  font-family: 'Maledpan', 'Sarabun';
+  font-weight: bold;
+  font-size: 1.5rem;
+  margin-top: 15px;
+  color: white;
+  margin-bottom: 8px;
+}
+.__nuxt-error-page .description {
+  color: #7F828B;
+  line-height: 21px;
+  margin-bottom: 10px;
+}
+.__nuxt-error-page a {
+  color: #7F828B !important;
+  text-decoration: none;
+}
+.__nuxt-error-page .logo {
+  position: fixed;
+  left: 12px;
+  bottom: 12px;
+}
+</style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -81,6 +81,9 @@ const config = {
   /*
   ** Build configuration
   */
+  generate: {
+    fallback: true // For Firebase Hosting, see https://nuxtjs.org/api/configuration-generate#fallback
+  },
   build: {
     // Fix ES6 for IE11
     transpile: [


### PR DESCRIPTION
Don't know if this is required...
- Set Nuxt config to generate `404.html` instead of `200.html`.
- Set Firebase to redirect non-existing paths to `404.html` (SPA mode fallback).
- Replace default Error Page with YWC17 color scheme.