### PR TITLE
Disable rewrite to trigger actual 404

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,8 +11,8 @@
       ],
       "rewrites": [
         {
-          "source": "**",
-          "destination": "/404.html"
+          "source": "/",
+          "destination": "/index.html"
         }
       ]
     },
@@ -26,8 +26,8 @@
       ],
       "rewrites": [
         {
-          "source": "**",
-          "destination": "/404.html"
+          "source": "/",
+          "destination": "/index.html"
         }
       ]
     }


### PR DESCRIPTION
I just realize Nuxt.js generate directories to make routes exist. (i.e. `/candidate` => `candidate/index.html`)
Then, we have no need to rewrite as SPA anymore;
**now Firebase can trigger actual 404 HTTP Status Code** via `404.html`