### PR TITLE
Fix body width overflow 2

### DIFF
--- a/components/sections/Sponsor.vue
+++ b/components/sections/Sponsor.vue
@@ -131,6 +131,11 @@ section {
     font-size: 36px;
   }
 }
+@media screen and (max-width:330px) {
+  .height {
+    font-size: 32px;
+  }
+}
 </style>
 <style lang="scss">
 .sp-ExxonMobil {


### PR DESCRIPTION
- Reduce Sponsor heading `font-size` on small breakpoint to fix body width overflow