### PR TITLE
Remove Guru slide interval on destroy

### DIFF
--- a/components/sections/Guru.vue
+++ b/components/sections/Guru.vue
@@ -150,6 +150,11 @@ export default {
   created () {
     this.setAutoplay()
   },
+  beforeDestroy () {
+    if (this.autoplay) {
+      clearInterval(this.autoplay)
+    }
+  },
   methods: {
     setAutoplay () {
       if (this.autoplay) {


### PR DESCRIPTION
Prevent errors ocurred from time interval after routing between SPA pages.