### PR TITLE
Fix PR large button style

### DIFF
--- a/components/sections/PR.vue
+++ b/components/sections/PR.vue
@@ -24,12 +24,11 @@ section {
 }
 </style>
 <style>
-.large {
+a.large {
   display: block;
   margin: 0 auto;
   transform: scale(1.3);
   min-width: 220px;
-  width: 50%;
 }
 a {
   text-decoration: none;


### PR DESCRIPTION
Remove `width` rule from PR `large` class which caused the buttons rendered by SPA and Generated are different.